### PR TITLE
Raise exception to halt Django from deleting job

### DIFF
--- a/uit_plus_job/models.py
+++ b/uit_plus_job/models.py
@@ -718,14 +718,18 @@ class UitPlusJob(PbsScript, TethysJob):
         """
         try:
             archive = bool(self.extended_properties.get('archived_job_id'))
-            self.stop()
+            stop_result = self.stop()
+            if stop_result is False:
+                raise Exception('Delete failed while performing job cleanup.')
+
             try:
                 if self.clean_on_delete:
                     self.clean(archive=archive)
             except AttributeError:
                 self.clean(archive=archive)
         except Exception as e:
-            log.exception(str(e))
+            log.exception(f"Error during job delete: {e}")
+            raise  # Let Django know to display the error message to the user
         super().delete(using, keep_parents)
 
     def clean(self, archive=False):

--- a/uit_plus_job/models.py
+++ b/uit_plus_job/models.py
@@ -1,5 +1,6 @@
 # Put your persistent store models in this file
 import os
+import posixpath
 import re
 import shutil
 import threading
@@ -417,7 +418,7 @@ class UitPlusJob(PbsScript, TethysJob):
         """
         if self._archive_dir is None:
             archive_home = self.get_environment_variable('ARCHIVE_HOME')
-            self._archive_dir = os.path.join(archive_home, self.remote_workspace_suffix)
+            self._archive_dir = posixpath.join(archive_home, self.remote_workspace_suffix)
         return self._archive_dir
 
     @property
@@ -449,7 +450,7 @@ class UitPlusJob(PbsScript, TethysJob):
             str: The job home directory
         """
         if self._home_dir is None:
-            self._home_dir = os.path.join(self.client.HOME, self.remote_workspace_suffix)
+            self._home_dir = posixpath.join(self.client.HOME, self.remote_workspace_suffix)
         return self._home_dir
 
     @property
@@ -745,7 +746,7 @@ class UitPlusJob(PbsScript, TethysJob):
         """  # noqa: E501
         # Remove local workspace
         if self.workspace:
-            log.warning(f'Removing {self.workspace}')
+            log.warning(f'Removing local workspace {self.workspace}')
             thread = threading.Thread(target=shutil.rmtree, args=(self.workspace, True))
             thread.daemon = True
             thread.start()


### PR DESCRIPTION
CHW-232 Do not delete job when host cannot be reached
stop() runs 'qdel', and it will now raise an exception if it fails. Django will listen to that and not continue with deleting the job from jobs_table.
I think the exception worked with the pre_delete receiver, but I think it's cleaner and more direct to use an inherited delete() method.
I ran this on Windows, and it was trying to delete a path on the HPC with a backslash in the middle. I went with posixpath since that is a direct substitute for os.path.