### PR TITLE
Fix archiving on other HPCs

### DIFF
--- a/uit_plus_job/models.py
+++ b/uit_plus_job/models.py
@@ -782,7 +782,8 @@ class UitPlusJob(PbsScript, TethysJob):
                 processes_per_node=1,
                 max_time="01:00:00",
                 queue="transfer",
-                node_type="transfer"
+                node_type="transfer",
+                system=self.system
         )
         pbs_script.execution_block = (
             f"tar -czf {archive_filename} *\n"


### PR DESCRIPTION
CHW-427
When I attempt to Archive a job on an HPC besides Onyx in the Helios Tethys app, it saves the .pbs file and runs qsub on Onyx.

The _archive() code was not passing the system to PbsScript, which defaults to onyx.