### PR TITLE
Set _array_indices to None in manual migration script

### DIFF
--- a/uit_plus_job/migrations/manual/load_uit_array_data.py
+++ b/uit_plus_job/migrations/manual/load_uit_array_data.py
@@ -42,4 +42,6 @@ for job in UitPlusJob.objects.all():
     job._optional_directives = json.loads(row_data['_optional_directives'])
     if row_data['_array_indices']:
         job._array_indices = [int(i) for i in json.loads(row_data['_array_indices'])]
+    else:
+        job._array_indices = None
     job.save()


### PR DESCRIPTION
Before, this script set _array_indices to [] if it was None/NULL before the migration. Now it carries over the None/NULL value. New entries to the database also use None/NULL.

A value of [] caused problems in pyuit/pbs_script.py:202 number_of_sub_jobs() "if self._array_indices is not None:" when displaying the jobs_table. That line is now fixed, but it also causes an error a few lines above during a job restart.