### PR TITLE
Increase archive walltime to 48 hours

### DIFF
--- a/uit_plus_job/models.py
+++ b/uit_plus_job/models.py
@@ -813,7 +813,7 @@ class UitPlusJob(PbsScript, TethysJob):
                 project_id=self.pbs_job.script.project_id,
                 num_nodes=1,
                 processes_per_node=1,
-                max_time="01:00:00",
+                max_time="48:00:00",
                 queue="transfer",
                 node_type="transfer",
                 system=self.system


### PR DESCRIPTION
1 hour was not long enough for many archive jobs. All of our supported HPCs have a maximum of 48 hours for the transfer queue.

CHW-525