### PR TITLE
Fix ParamFutureWarning with ClassSelector

### DIFF
--- a/uit_plus_job/submit_stage.py
+++ b/uit_plus_job/submit_stage.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 
 
 class TethysProfileManagement(PbsScriptAdvancedInputs):
-    tethys_user = param.ClassSelector(User)
+    tethys_user = param.ClassSelector(class_=User)
     environment_profile = param.Selector(label="Load Environment Profile")
     environment_profile_delete = param.Selector(label="Environment Profile to Delete")
     environment_profile_version = param.Selector(allow_None=True, precedence=2)


### PR DESCRIPTION
Param 2.0 does not want any positional arguments for ClassSelector. https://param.holoviz.org/upgrade_guide.html#deprecations

This PR addresses these deprecation warnings: `ParamFutureWarning: Passing 'class_' as positional argument(s) to 'param.ClassSelector' has been deprecated since Param 2.0.0 and will raise an error in a future version, please pass them as keyword arguments.`

CHW-664