### PR TITLE
Avoid connecting to HPC on every update_status

### DIFF
--- a/uit_plus_job/models.py
+++ b/uit_plus_job/models.py
@@ -547,7 +547,6 @@ class UitPlusJob(PbsScript, TethysJob):
         await self.execute(*args, **kwargs)
 
     # duplicate from Tethys to make it async
-    @_ensure_connected
     async def update_status(self, status=None, *args, **kwargs):
         """
         Updates the status of a job. If ``status`` is passed then it will manually update the status. Otherwise,
@@ -593,6 +592,7 @@ class UitPlusJob(PbsScript, TethysJob):
 
         await self._safe_save()
 
+    @_ensure_connected
     async def _update_status(self):
         """Retrieve a job’s status using the UIT Plus Python client.
 


### PR DESCRIPTION
This change moves @_ensure_connected from update_status() to _update_status() where the HPC calls occur. update_status() usually avoids HPC calls because the job's status is already Completed.

Before this change, completed jobs on an HPC down for maintenance would show an "unexpected error occurred" line. 

CHW-672