### PR TITLE
Fix process_results() not calling get_remote_files()

### DIFF
--- a/uit_plus_job/tests/integrated_tests/test_models.py
+++ b/uit_plus_job/tests/integrated_tests/test_models.py
@@ -1,4 +1,5 @@
-import mock
+import asyncio
+from unittest import mock
 import datetime
 from uit_plus_job.models import UitPlusJob
 from uit.exceptions import DpRouteError
@@ -343,7 +344,9 @@ class TestUitPlusJob(TransactionTestCase):
         remote_files_names = ["file1.xml"]
         remote_dir = "WORKDIR"
         mock_client.get_file.return_value = {"success": True}
-        self.assertFalse(self.uitplusjob.get_remote_files(remote_dir=remote_dir, remote_filenames=remote_files_names))
+        self.assertFalse(
+            asyncio.run(self.uitplusjob.get_remote_files(remote_dir=remote_dir, remote_filenames=remote_files_names))
+        )
 
     @mock.patch("uit_plus_job.models.log")
     @mock.patch("uit_plus_job.models.UitPlusJob.client")
@@ -353,7 +356,7 @@ class TestUitPlusJob(TransactionTestCase):
         mock_client.get_file.side_effect = IOError
 
         # call the method
-        ret = self.uitplusjob.get_remote_files(remote_dir=remote_dir, remote_filenames=remote_files_names)
+        ret = asyncio.run(self.uitplusjob.get_remote_files(remote_dir=remote_dir, remote_filenames=remote_files_names))
 
         # test results
         self.assertFalse(ret)
@@ -367,7 +370,7 @@ class TestUitPlusJob(TransactionTestCase):
         mock_os.path.join.side_effect = ["local_path", "remote_path"]
         mock_client.get_file.return_value = {"success": True}
         mock_os.path.exists.return_value = True
-        ret = self.uitplusjob.get_remote_files(remote_dir=remote_dir, remote_filenames=remote_files_names)
+        ret = asyncio.run(self.uitplusjob.get_remote_files(remote_dir=remote_dir, remote_filenames=remote_files_names))
 
         # test results
         self.assertTrue(ret)

--- a/uit_plus_job/tests/unit_tests/test_oauth2.py
+++ b/uit_plus_job/tests/unit_tests/test_oauth2.py
@@ -34,9 +34,9 @@ class UitPlusOAuth2Tests(unittest.TestCase):
         self.assertIn(("USERNAME", "email"), self.auth.EXTRA_DATA)
         self.assertIn(("USERNAME", "id"), self.auth.EXTRA_DATA)
         self.assertIn(("SYSTEMS", "systems"), self.auth.EXTRA_DATA)
-        self.assertIn(("access_token_expires_on", "expires_in"), self.auth.EXTRA_DATA)
+        self.assertIn(("access_token_expires_on", "expires"), self.auth.EXTRA_DATA)
         self.assertIn(("refresh_token", "refresh_token"), self.auth.EXTRA_DATA)
-        self.assertIn(("refresh_token_expires_on", "refresh_expires_in"), self.auth.EXTRA_DATA)
+        self.assertIn(("refresh_token_expires_on", "refresh_expires_on"), self.auth.EXTRA_DATA)
 
     def test_get_user_details_with_hpc_username(self):
         hpc_username = "foo@bar.com"


### PR DESCRIPTION
After a job completed, this no longer downloaded remote files because of switching to the AsyncUitClient. This change uses async and await for get_remote_files(). It used to wander into Tethys code with process_results() and _process_results(), so I recreated that in a new function named async_process_results(). I also had to await the async_process_results() because it has the @database_sync_to_async decorator.

I am not that comfortable with async, so I definitely welcome any opinions around that. I am not confident that async_process_results() is a good name.

I don't use transfer_intermediate_files, so I have not been able to test that change.

CHW-680