### PR TITLE
Enable refresh token

### DIFF
--- a/uit_plus_job/models.py
+++ b/uit_plus_job/models.py
@@ -16,6 +16,7 @@ from django.db import models
 from django.utils import timezone
 from django.db.models import JSONField
 from django.contrib.auth.models import User
+from social_django.utils import load_strategy
 from tethys_apps.base.function_extractor import TethysFunctionExtractor
 from uit.exceptions import UITError
 from uit import AsyncClient, PbsScript, PbsJob, PbsArrayJob
@@ -401,7 +402,7 @@ class UitPlusJob(PbsScript, TethysJob):
     def get_token(self):
         try:
             social = self.user.social_auth.get(provider="UITPlus")
-            self._token = social.extra_data["access_token"]
+            self._token = social.get_access_token(load_strategy())
         except (KeyError, AttributeError):
             self._token = None
 

--- a/uit_plus_job/oauth2.py
+++ b/uit_plus_job/oauth2.py
@@ -7,7 +7,7 @@
 ********************************************************************************
 """
 
-from datetime import datetime
+from datetime import datetime, UTC, timedelta
 
 from social_core.backends.oauth import BaseOAuth2
 from uit.uit import DEFAULT_CA_FILE
@@ -37,15 +37,20 @@ class UitPlusOAuth2(BaseOAuth2):
         ("USERNAME", "email"),
         ("USERNAME", "id"),
         ("SYSTEMS", "systems"),
-        ("access_token_expires_on", "expires"),
+        ("expires_on", "expires_on"),
+        ("expires_in", "expires_in"),
+        ("expires_in", "expires"),
         ("refresh_token", "refresh_token"),
-        ("refresh_token_expires_on", "refresh_expires_on"),
+        ("refresh_token_expires_on", "refresh_token_expires_on"),
+        ("access_token_expires_on", "access_token_expires_on"),
     ]
 
     def extra_data(self, user, uid, response, details=None, *args, **kwargs):
         # convert date string to timestamp
-        expires_time = datetime.fromisoformat(response["access_token_expires_on"].replace("Z", ""))
-        response["access_token_expires_on"] = datetime.timestamp(expires_time)
+        expires_time = datetime.fromisoformat(response["access_token_expires_on"])
+        auth_time = datetime.now(UTC)
+        response["expires_on"] = datetime.timestamp(expires_time - timedelta(days=2))
+        response["expires_in"] = (expires_time - auth_time).seconds
         return super().extra_data(user, uid, response, details, *args, **kwargs)
 
     def get_user_details(self, response):


### PR DESCRIPTION
modify oauth to enable the expiry calculations to work so refresh token can be used to update the access token