### PR TITLE
Allow delete() to work on decommissioned systems

### DIFF
--- a/uit_plus_job/models.py
+++ b/uit_plus_job/models.py
@@ -702,7 +702,6 @@ class UitPlusJob(PbsScript, TethysJob):
         """
         return await self.pbs_job.release()
 
-    @_ensure_connected
     async def delete(self, using=None, keep_parents=False):
         """Stops the job and cleans up workspaces in order to delete the job."""
         try:


### PR DESCRIPTION
The @_ensure_connected decorator forces a connection attempt to the HPC before deleting the job, and that fails on any system that no longer exists.