### PR TITLE
Change VERIFY_SSL default setting with specified cert file

### DIFF
--- a/uit_plus_job/oauth2.py
+++ b/uit_plus_job/oauth2.py
@@ -91,7 +91,11 @@ class UitPlusOAuth2(BaseOAuth2):
             return response
 
     def setting(self, name, default=None):
-        """Point the VERIFY_SSL setting to the dodcerts module, which has a dynamic location"""
+        """Point the VERIFY_SSL setting to the dodcerts module
+
+        The certificate file provided by dodcerts could be installed in several different locations,
+        and that makes it impractical to set VERIFY_SSL in a config file."""
         if name == "VERIFY_SSL":
-            default = DEFAULT_CA_FILE  # Allow a config file to override this
+            # Modify only the default here so the config file can override this change
+            default = DEFAULT_CA_FILE
         return super().setting(name, default)

--- a/uit_plus_job/oauth2.py
+++ b/uit_plus_job/oauth2.py
@@ -90,5 +90,8 @@ class UitPlusOAuth2(BaseOAuth2):
             # Return the get token response if errors occur
             return response
 
-    def request(self, url, method="GET", *args, **kwargs):  # noqa: B026
-        return super().request(url, method, *args, verify=DEFAULT_CA_FILE, **kwargs)
+    def setting(self, name, default=None):
+        """Point the VERIFY_SSL setting to the dodcerts module, which has a dynamic location"""
+        if name == "VERIFY_SSL":
+            default = DEFAULT_CA_FILE  # Allow a config file to override this
+        return super().setting(name, default)


### PR DESCRIPTION
social-auth-core [version 4.6.0](https://github.com/python-social-auth/social-core/releases/tag/4.6.0) updated [their request() function](https://github.com/python-social-auth/social-core/commit/328f0c1dfb4ca1def5f3a11bfe09a1e42e7fa632#diff-c67d3a0d589762fbdea8b94a7cccec5a5535646d724b58308a051fc6949a4ef2L231) which broke our method of telling the Requests library to trust other certificates when connecting to UIT+. The update blocks our ability to set the verify= argument. The tricky part is that DEFAULT_CA_FILE can change since it typically points to a python module, so setting SOCIAL_AUTH_VERIFY_SSL isn't a good option here.

This change overrides the VERIFY_SSL setting, and this should last longer in future code changes to social-auth. This also works with older versions of social-auth, like what is in our local dev environments.

CHW-702